### PR TITLE
Disable next-auth & add databases tab

### DIFF
--- a/app/app/databases/page.js
+++ b/app/app/databases/page.js
@@ -1,0 +1,9 @@
+
+export const metadata = {
+  title: "Databases",
+  description: "Manage your databases",
+};
+
+export default function DatabasesPage() {
+  return <div>Databases page</div>;
+}

--- a/app/app/layout.js
+++ b/app/app/layout.js
@@ -1,6 +1,6 @@
-import { getServerSession } from "next-auth/next";
-import { redirect } from "next/navigation";
-import { authOptions } from "pages/api/auth/[...nextauth]";
+// import { getServerSession } from "next-auth/next";
+// import { redirect } from "next/navigation";
+// import { authOptions } from "pages/api/auth/[...nextauth]";
 import AppContainer from "./container";
 
 export const metadata = {

--- a/app/app/layout.js
+++ b/app/app/layout.js
@@ -9,11 +9,11 @@ export const metadata = {
 };
 
 export default async function AppLayout({ children }) {
-  const session = await getServerSession(authOptions);
+  // const session = await getServerSession(authOptions);
 
-  if (!session) {
-    redirect("/");
-  }
+  // if (!session) {
+  //   redirect("/");
+  // }
 
   return <AppContainer>{children}</AppContainer>;
 }

--- a/lib/sidebar.js
+++ b/lib/sidebar.js
@@ -27,13 +27,13 @@ export const useSidebar = () => {
       icon: TbHome,
       placement: PLACEMENT.top,
     },
-    {
-      id: "datasources",
-      label: "Datasources",
-      href: "/app/datasources",
-      icon: TbDatabase,
-      placement: PLACEMENT.top,
-    },
+    // {
+    //   id: "datasources",
+    //   label: "Datasources",
+    //   href: "/app/datasources",
+    //   icon: TbDatabase,
+    //   placement: PLACEMENT.top,
+    // },
     {
       id: "prompt_templates",
       label: "Prompt templates",
@@ -41,11 +41,18 @@ export const useSidebar = () => {
       icon: TbPrompt,
       placement: PLACEMENT.top,
     },
+    // {
+    //   id: "chatbots",
+    //   label: "Chatbots",
+    //   href: "/app/chatbots",
+    //   icon: TbMessage,
+    //   placement: PLACEMENT.top,
+    // },
     {
-      id: "chatbots",
-      label: "Chatbots",
-      href: "/app/chatbots",
-      icon: TbMessage,
+      id: "databases",
+      label: "Databases",
+      href: "/app/databases",
+      icon: TbDatabase,
       placement: PLACEMENT.top,
     },
     {


### PR DESCRIPTION
## Summary

- Disable next-auth for home page
- Hide chatbots, datasources tabs
- Add databases tab

Fixes

Depends on

## Test plan

<!-- Include the steps to test your PR -->

-

## Screenshots

<img width="1247" alt="image" src="https://github.com/homanp/langchain-ui/assets/142542915/c48aaf7b-407a-4830-be8f-cbac7ab41ce1">
